### PR TITLE
Fix/nav decryption

### DIFF
--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -12,6 +12,7 @@ import { WebpubManifest } from './WebpubManifestTypes/WebpubManifest';
 import { epubToManifest } from './convert';
 import Decryptor from '@nypl-simplified-packages/axisnow-access-control-web';
 import Fetcher from './Fetcher';
+import { getEncryptionInfo } from './convert/encryption';
 
 /**
  * This class represents a complete EPUB. It is abstract
@@ -58,6 +59,7 @@ export default class Epub {
       isAxisNow?: boolean;
     } = { decryptor: undefined, isAxisNow: false }
   ) {
+    console.log('BUILDING');
     const container = Epub.parseContainer(
       await fetcher.getFileStr(containerXmlPath)
     );
@@ -65,32 +67,62 @@ export default class Epub {
     const opfPath = fetcher.getOpfPath(relativeOpfPath);
     const opf = await Epub.parseOpf(await fetcher.getFileStr(opfPath));
 
-    const relativeNcxPath = Epub.getNcxHref(opf);
-    const ncxPath = relativeNcxPath
-      ? fetcher.resolvePath(opfPath, relativeNcxPath)
-      : undefined;
-
-    const ncxBuffer = ncxPath
-      ? await fetcher.getArrayBuffer(ncxPath)
-      : undefined;
-    const ncxStr = await Epub.decryptStr(ncxBuffer, decryptor);
-    const ncx = Epub.parseNcx(ncxStr);
-
-    const relativeNavDocPath = Epub.getNavDocHref(opf);
-    const navDocPath = relativeNavDocPath
-      ? fetcher.resolvePath(opfPath, relativeNavDocPath)
-      : undefined;
-    const navDocBuffer = navDocPath
-      ? await fetcher.getArrayBuffer(navDocPath)
-      : undefined;
-    const navDocStr = await Epub.decryptStr(navDocBuffer, decryptor);
-    const navDoc = Epub.parseNavDoc(navDocStr);
-
     // if there is no encryption path, the encryptionDoc will be undefined
     // and the EPUB will be assumed unencrypted.
     const encryptionPath = fetcher.getEncryptionPath(containerXmlPath);
     const encryptionStr = await fetcher.getOptionalFileStr(encryptionPath);
     const encryptionDoc = Epub.parseEncryptionDoc(encryptionStr);
+
+    // ncx file
+    const relativeNcxPath = Epub.getNcxHref(opf);
+    const ncxPath = relativeNcxPath
+      ? fetcher.resolvePath(opfPath, relativeNcxPath)
+      : undefined;
+
+    let ncx: NCX | undefined = undefined;
+    if (ncxPath) {
+      // it is encrypted if there is an entry for it in encryption.xml
+      const ncxIsEncrypted = !!getEncryptionInfo(
+        encryptionDoc,
+        ncxPath,
+        isAxisNow
+      );
+      if (ncxIsEncrypted) {
+        const ncxBuffer = ncxPath
+          ? await fetcher.getArrayBuffer(ncxPath)
+          : undefined;
+        const ncxStr = await Epub.decryptStr(ncxBuffer, decryptor);
+        ncx = Epub.parseNcx(ncxStr);
+      } else {
+        const ncxStr = await fetcher.getFileStr(ncxPath);
+        ncx = Epub.parseNcx(ncxStr);
+      }
+    }
+
+    // navdoc file
+    const relativeNavDocPath = Epub.getNavDocHref(opf);
+    const navDocPath = relativeNavDocPath
+      ? fetcher.resolvePath(opfPath, relativeNavDocPath)
+      : undefined;
+
+    let navDoc: Document | undefined = undefined;
+    if (navDocPath) {
+      const isNavDocEncrypted = !!getEncryptionInfo(
+        encryptionDoc,
+        navDocPath,
+        isAxisNow
+      );
+      if (isNavDocEncrypted) {
+        const navDocBuffer = navDocPath
+          ? await fetcher.getArrayBuffer(navDocPath)
+          : undefined;
+        const navDocStr = await Epub.decryptStr(navDocBuffer, decryptor);
+        navDoc = Epub.parseNavDoc(navDocStr);
+      } else {
+        const navDocStr = await fetcher.getFileStr(navDocPath);
+        navDoc = Epub.parseNavDoc(navDocStr);
+      }
+    }
 
     return new Epub(
       fetcher,
@@ -137,6 +169,14 @@ export default class Epub {
   get webpubManifest(): Promise<WebpubManifest> {
     return epubToManifest(this);
   }
+
+  static async getNcx(
+    opf: OPF,
+    opfPath: string,
+    encryptionDoc: Encryption | undefined,
+    fetcher: Fetcher,
+    isAxisNow: boolean | undefined
+  ) {}
 
   ///////////////////
   // METHODS FOR DESERIALIZING VALUES INTO IN-MEMORY CLASSES
@@ -267,6 +307,10 @@ export default class Epub {
   ): Promise<ArrayBuffer> {
     if (!decryptor) return buffer;
     return await decryptor.decrypt(new Uint8Array(buffer));
+  }
+
+  getLinkEncryption(relativePath: string) {
+    return getEncryptionInfo(this.encryptionDoc, relativePath, this.isAxisNow);
   }
 
   ///////////////////

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -170,14 +170,6 @@ export default class Epub {
     return epubToManifest(this);
   }
 
-  static async getNcx(
-    opf: OPF,
-    opfPath: string,
-    encryptionDoc: Encryption | undefined,
-    fetcher: Fetcher,
-    isAxisNow: boolean | undefined
-  ) {}
-
   ///////////////////
   // METHODS FOR DESERIALIZING VALUES INTO IN-MEMORY CLASSES
   ///////////////////

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -1,3 +1,5 @@
+import { Encryption } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption';
+import { EncryptedData } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption-data';
 import { AxisNowEncryptionScheme } from '../constants';
 import Epub from '../Epub';
 import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtension';
@@ -6,8 +8,12 @@ import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtensio
  * Adds encryption information to the resource link if there is any detected for this
  * link in the epub.encryptionDoc
  */
-export default function getLinkEncryption(epub: Epub, relativePath: string) {
-  const encryptionData = epub.encryptionDoc?.EncryptedData.find(
+export function getEncryptionInfo(
+  encryptionDoc: Encryption | undefined,
+  relativePath: string,
+  isAxisNow: boolean | undefined
+) {
+  const encryptionData = encryptionDoc?.EncryptedData.find(
     (data) => data.CipherData.CipherReference.URI === relativePath
   );
   const algorithm = encryptionData?.EncryptionMethod.Algorithm;
@@ -20,7 +26,7 @@ export default function getLinkEncryption(epub: Epub, relativePath: string) {
    * using.
    */
   if (algorithm) {
-    if (epub.isAxisNow) {
+    if (isAxisNow) {
       encryption = {
         algorithm,
         scheme: AxisNowEncryptionScheme,

--- a/src/convert/resourcesAndReadingOrder.ts
+++ b/src/convert/resourcesAndReadingOrder.ts
@@ -1,7 +1,6 @@
 import { Manifest } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/opf-manifest';
 import Epub from '../Epub';
 import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
-import getLinkEncryption from './encryption';
 
 /**
  * The readingOrder lists the resources of the publication in the reading order
@@ -103,7 +102,7 @@ const manifestToLink =
     };
 
     // add encryption information if present
-    const enc = getLinkEncryption(epub, relativePath);
+    const enc = epub.getLinkEncryption(relativePath);
     if (enc) {
       link.properties = { encrypted: enc };
     }


### PR DESCRIPTION
In my previous PR I didn't use the `encryption.xml` to determine if the `NCX` or `NavDoc` were encrypted. This fixes that by checking the encryption status of those documents before trying to decrypt them.