### PR TITLE
Absolute URL option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "sade": "^1.7.4",
         "size-limit": "^4.11.0",
         "tslib": "^2.2.0",
-        "tsup": "^4.14.0",
+        "tsup": "^5.1.0",
         "typescript": "^4.2.4"
       },
       "engines": {
@@ -5718,9 +5718,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.12.27",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.27.tgz",
-      "integrity": "sha512-G42siADcTdRU1qRBxhiIiVLG4gcEMyWV4CWfLBdSii+olCueZJHFRHc7EqQRnRvNkSQq88i0k1Oufw/YVueUWQ==",
+      "version": "0.12.28",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
+      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -18001,9 +18001,9 @@
       }
     },
     "node_modules/sucrase": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.18.2.tgz",
-      "integrity": "sha512-xCFP35OA6uAtBUVB8jPSftiR2Udjh0d9JkQnUOYppILpN4rBSk0yxiy67GVzD3XsFGIB6LlyIfhCABtwlopMSw==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.20.1.tgz",
+      "integrity": "sha512-BIG59HaJOxNct9Va6KvT5yzBA/rcMGetzvZyTx0ZdCcspIbpJTPS64zuAfYlJuOj+3WaI5JOdA+F0bJQQi8ZiQ==",
       "dev": true,
       "dependencies": {
         "commander": "^4.0.0",
@@ -18605,23 +18605,23 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/tsup": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-4.14.0.tgz",
-      "integrity": "sha512-77rWdzhikTP9mQ34XMRzK83tw++LF6f4ox/HNERlgesB7g6g5VQ1iJlueG9O0P9HAZGVKavUwyoZv0+322p6rg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-5.1.0.tgz",
+      "integrity": "sha512-shox7rIKPneySkC6CI7py1N1Buqlp++sofTztZxGAESP4od2WrPD/y0FwNo6+XaoXfuzVV6bDAwvCtDpc0bq1A==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.2",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.1",
         "debug": "^4.3.1",
-        "esbuild": "^0.12.9",
+        "esbuild": "^0.12.28",
         "execa": "^5.0.0",
         "globby": "^11.0.3",
         "joycon": "^3.0.1",
         "postcss-load-config": "^3.0.1",
         "resolve-from": "^5.0.0",
         "rollup": "^2.56.1",
-        "sucrase": "^3.18.1",
+        "sucrase": "^3.20.1",
         "tree-kill": "^1.2.2"
       },
       "bin": {
@@ -25164,9 +25164,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.27",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.27.tgz",
-      "integrity": "sha512-G42siADcTdRU1qRBxhiIiVLG4gcEMyWV4CWfLBdSii+olCueZJHFRHc7EqQRnRvNkSQq88i0k1Oufw/YVueUWQ==",
+      "version": "0.12.28",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
+      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA==",
       "dev": true
     },
     "esbuild-jest": {
@@ -34667,9 +34667,9 @@
       }
     },
     "sucrase": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.18.2.tgz",
-      "integrity": "sha512-xCFP35OA6uAtBUVB8jPSftiR2Udjh0d9JkQnUOYppILpN4rBSk0yxiy67GVzD3XsFGIB6LlyIfhCABtwlopMSw==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.20.1.tgz",
+      "integrity": "sha512-BIG59HaJOxNct9Va6KvT5yzBA/rcMGetzvZyTx0ZdCcspIbpJTPS64zuAfYlJuOj+3WaI5JOdA+F0bJQQi8ZiQ==",
       "dev": true,
       "requires": {
         "commander": "^4.0.0",
@@ -35128,23 +35128,23 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "tsup": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-4.14.0.tgz",
-      "integrity": "sha512-77rWdzhikTP9mQ34XMRzK83tw++LF6f4ox/HNERlgesB7g6g5VQ1iJlueG9O0P9HAZGVKavUwyoZv0+322p6rg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-5.1.0.tgz",
+      "integrity": "sha512-shox7rIKPneySkC6CI7py1N1Buqlp++sofTztZxGAESP4od2WrPD/y0FwNo6+XaoXfuzVV6bDAwvCtDpc0bq1A==",
       "dev": true,
       "requires": {
         "cac": "^6.7.2",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.1",
         "debug": "^4.3.1",
-        "esbuild": "^0.12.9",
+        "esbuild": "^0.12.28",
         "execa": "^5.0.0",
         "globby": "^11.0.3",
         "joycon": "^3.0.1",
         "postcss-load-config": "^3.0.1",
         "resolve-from": "^5.0.0",
         "rollup": "^2.56.1",
-        "sucrase": "^3.18.1",
+        "sucrase": "^3.20.1",
         "tree-kill": "^1.2.2"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.5",
+  "version": "0.3.6-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/epub-to-webpub",
-      "version": "0.3.5",
+      "version": "0.3.6-0",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.77",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-2",
+  "version": "0.3.6-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/epub-to-webpub",
-      "version": "0.3.6-2",
+      "version": "0.3.6-3",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.77",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-0",
+  "version": "0.3.6-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/epub-to-webpub",
-      "version": "0.3.6-0",
+      "version": "0.3.6-1",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.77",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-1",
+  "version": "0.3.6-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/epub-to-webpub",
-      "version": "0.3.6-1",
+      "version": "0.3.6-2",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.77",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true,
-    "dts": true,
+    "dts": {
+      "entry": {
+        "index": "src/index.ts"
+      }
+    },
     "format": [
       "esm",
       "cjs"
@@ -99,7 +103,7 @@
     "sade": "^1.7.4",
     "size-limit": "^4.11.0",
     "tslib": "^2.2.0",
-    "tsup": "^4.14.0",
+    "tsup": "^5.1.0",
     "typescript": "^4.2.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-2",
+  "version": "0.3.6-3",
   "license": "MIT",
   "repository": "https://github.com/NYPL/ePub-to-webpub",
   "author": "kristojorg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-0",
+  "version": "0.3.6-1",
   "license": "MIT",
   "repository": "https://github.com/NYPL/ePub-to-webpub",
   "author": "kristojorg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.5",
+  "version": "0.3.6-0",
   "license": "MIT",
   "repository": "https://github.com/NYPL/ePub-to-webpub",
   "author": "kristojorg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "0.3.6-1",
+  "version": "0.3.6-2",
   "license": "MIT",
   "repository": "https://github.com/NYPL/ePub-to-webpub",
   "author": "kristojorg",

--- a/samples/moby-webpub/manifest-absolute-hrefs.json
+++ b/samples/moby-webpub/manifest-absolute-hrefs.json
@@ -1,0 +1,754 @@
+{
+  "@context": "https://readium.org/webpub-manifest/context.jsonld",
+  "metadata": {
+    "@type": "http://schema.org/Book",
+    "title": "Moby Dick; Or, The Whale",
+    "identifier": "http://www.gutenberg.org/2701",
+    "author": "Herman Melville",
+    "language": "en",
+    "modified": "Tue Feb 14 2017 04:51:48 GMT-0800 (Pacific Standard Time)",
+    "rights": "Public domain in the USA.",
+    "source": "https://www.gutenberg.org/files/2701/2701-h/2701-h.htm",
+    "subject": [
+      "Whaling -- Fiction",
+      "Sea stories",
+      "Psychological fiction",
+      "Ship captains -- Fiction",
+      "Adventure stories",
+      "Mentally ill -- Fiction",
+      "Ahab, Captain (Fictitious character) -- Fiction",
+      "Whales -- Fiction",
+      "Whaling ships -- Fiction"
+    ],
+    "cover": "item1"
+  },
+  "readingOrder": [
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/wrap0000.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-1.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-8.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-9.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-22.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-23.htm.html"
+    },
+    {
+      "type": "application/xhtml+xml",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-24.htm.html"
+    }
+  ],
+  "resources": [
+    {
+      "type": "image/png",
+      "height": 1800,
+      "width": 1200,
+      "rel": "cover",
+      "href": "OEBPS/@export@sunsite@users@gutenbackend@cache@epub@2701@2701-cover.png"
+    },
+    {
+      "type": "text/css",
+      "href": "OEBPS/pgepub.css"
+    },
+    {
+      "type": "text/css",
+      "href": "OEBPS/0.css"
+    },
+    {
+      "type": "text/css",
+      "href": "OEBPS/1.css"
+    },
+    {
+      "type": "application/x-dtbncx+xml",
+      "href": "OEBPS/toc.ncx"
+    }
+  ],
+  "toc": [
+    {
+      "title": "MOBY-DICK; or, THE WHALE.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00000"
+    },
+    {
+      "title": "Original Transcriber’s Notes:",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00001"
+    },
+    {
+      "title": "ETYMOLOGY.",
+      "children": [
+        {
+          "title": "(Supplied by a Late Consumptive Usher to a Grammar School.)",
+          "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00003"
+        }
+      ],
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00002"
+    },
+    {
+      "title": "EXTRACTS. (Supplied by a Sub-Sub-Librarian).",
+      "children": [
+        {
+          "title": "EXTRACTS.",
+          "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00005"
+        }
+      ],
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-0.htm.html#pgepubid00004"
+    },
+    {
+      "title": "CHAPTER 1. Loomings.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-1.htm.html#pgepubid00006"
+    },
+    {
+      "title": "CHAPTER 2. The Carpet-Bag.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-1.htm.html#pgepubid00007"
+    },
+    {
+      "title": "CHAPTER 3. The Spouter-Inn.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-1.htm.html#pgepubid00008"
+    },
+    {
+      "title": "CHAPTER 4. The Counterpane.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00009"
+    },
+    {
+      "title": "CHAPTER 5. Breakfast.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00010"
+    },
+    {
+      "title": "CHAPTER 6. The Street.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00011"
+    },
+    {
+      "title": "CHAPTER 7. The Chapel.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00012"
+    },
+    {
+      "title": "CHAPTER 8. The Pulpit.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00013"
+    },
+    {
+      "title": "CHAPTER 9. The Sermon.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-2.htm.html#pgepubid00014"
+    },
+    {
+      "title": "CHAPTER 10. A Bosom Friend.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00015"
+    },
+    {
+      "title": "CHAPTER 11. Nightgown.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00016"
+    },
+    {
+      "title": "CHAPTER 12. Biographical.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00017"
+    },
+    {
+      "title": "CHAPTER 13. Wheelbarrow.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00018"
+    },
+    {
+      "title": "CHAPTER 14. Nantucket.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00019"
+    },
+    {
+      "title": "CHAPTER 15. Chowder.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00020"
+    },
+    {
+      "title": "CHAPTER 16. The Ship.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-3.htm.html#pgepubid00021"
+    },
+    {
+      "title": "CHAPTER 17. The Ramadan.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00022"
+    },
+    {
+      "title": "CHAPTER 18. His Mark.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00023"
+    },
+    {
+      "title": "CHAPTER 19. The Prophet.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00024"
+    },
+    {
+      "title": "CHAPTER 20. All Astir.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00025"
+    },
+    {
+      "title": "CHAPTER 21. Going Aboard.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00026"
+    },
+    {
+      "title": "CHAPTER 22. Merry Christmas.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-4.htm.html#pgepubid00027"
+    },
+    {
+      "title": "CHAPTER 23. The Lee Shore.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00028"
+    },
+    {
+      "title": "CHAPTER 24. The Advocate.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00029"
+    },
+    {
+      "title": "CHAPTER 25. Postscript.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00030"
+    },
+    {
+      "title": "CHAPTER 26. Knights and Squires.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00031"
+    },
+    {
+      "title": "CHAPTER 27. Knights and Squires.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00032"
+    },
+    {
+      "title": "CHAPTER 28. Ahab.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00033"
+    },
+    {
+      "title": "CHAPTER 29. Enter Ahab; to Him, Stubb.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-5.htm.html#pgepubid00034"
+    },
+    {
+      "title": "CHAPTER 30. The Pipe.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html#pgepubid00035"
+    },
+    {
+      "title": "CHAPTER 31. Queen Mab.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html#pgepubid00036"
+    },
+    {
+      "title": "CHAPTER 32. Cetology.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html#pgepubid00037"
+    },
+    {
+      "title": "CHAPTER 33. The Specksnyder.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html#pgepubid00038"
+    },
+    {
+      "title": "CHAPTER 34. The Cabin-Table.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-6.htm.html#pgepubid00039"
+    },
+    {
+      "title": "CHAPTER 35. The Mast-Head.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00040"
+    },
+    {
+      "title": "CHAPTER 36. The Quarter-Deck.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00041"
+    },
+    {
+      "title": "CHAPTER 37. Sunset.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00042"
+    },
+    {
+      "title": "CHAPTER 38. Dusk.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00043"
+    },
+    {
+      "title": "CHAPTER 39. First Night-Watch.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00044"
+    },
+    {
+      "title": "CHAPTER 40. Midnight, Forecastle.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-7.htm.html#pgepubid00045"
+    },
+    {
+      "title": "CHAPTER 41. Moby Dick.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-8.htm.html#pgepubid00046"
+    },
+    {
+      "title": "CHAPTER 42. The Whiteness of the Whale.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-8.htm.html#pgepubid00047"
+    },
+    {
+      "title": "CHAPTER 43. Hark!",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-8.htm.html#pgepubid00048"
+    },
+    {
+      "title": "CHAPTER 44. The Chart.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-8.htm.html#pgepubid00049"
+    },
+    {
+      "title": "CHAPTER 45. The Affidavit.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-9.htm.html#pgepubid00050"
+    },
+    {
+      "title": "CHAPTER 46. Surmises.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-9.htm.html#pgepubid00051"
+    },
+    {
+      "title": "CHAPTER 47. The Mat-Maker.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-9.htm.html#pgepubid00052"
+    },
+    {
+      "title": "CHAPTER 48. The First Lowering.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-9.htm.html#pgepubid00053"
+    },
+    {
+      "title": "CHAPTER 49. The Hyena.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00054"
+    },
+    {
+      "title": "CHAPTER 50. Ahab’s Boat and Crew. Fedallah.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00055"
+    },
+    {
+      "title": "CHAPTER 51. The Spirit-Spout.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00056"
+    },
+    {
+      "title": "CHAPTER 52. The Albatross.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00057"
+    },
+    {
+      "title": "CHAPTER 53. The Gam.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00058"
+    },
+    {
+      "title": "CHAPTER 54. The Town-Ho’s Story.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-10.htm.html#pgepubid00059"
+    },
+    {
+      "title": "CHAPTER 55. Of the Monstrous Pictures of Whales.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00060"
+    },
+    {
+      "title": "CHAPTER 56. Of the Less Erroneous Pictures of Whales, and the True Pictures of Whaling Scenes.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00061"
+    },
+    {
+      "title": "CHAPTER 57. Of Whales in Paint; in Teeth; in Wood; in Sheet-Iron; in Stone; in Mountains; in Stars.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00062"
+    },
+    {
+      "title": "CHAPTER 58. Brit.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00063"
+    },
+    {
+      "title": "CHAPTER 59. Squid.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00064"
+    },
+    {
+      "title": "CHAPTER 60. The Line.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-11.htm.html#pgepubid00065"
+    },
+    {
+      "title": "CHAPTER 61. Stubb Kills a Whale.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00066"
+    },
+    {
+      "title": "CHAPTER 62. The Dart.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00067"
+    },
+    {
+      "title": "CHAPTER 63. The Crotch.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00068"
+    },
+    {
+      "title": "CHAPTER 64. Stubb’s Supper.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00069"
+    },
+    {
+      "title": "CHAPTER 65. The Whale as a Dish.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00070"
+    },
+    {
+      "title": "CHAPTER 66. The Shark Massacre.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00071"
+    },
+    {
+      "title": "CHAPTER 67. Cutting In.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-12.htm.html#pgepubid00072"
+    },
+    {
+      "title": "CHAPTER 68. The Blanket.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00073"
+    },
+    {
+      "title": "CHAPTER 69. The Funeral.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00074"
+    },
+    {
+      "title": "CHAPTER 70. The Sphynx.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00075"
+    },
+    {
+      "title": "CHAPTER 71. The Jeroboam’s Story.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00076"
+    },
+    {
+      "title": "CHAPTER 72. The Monkey-Rope.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00077"
+    },
+    {
+      "title": "CHAPTER 73. Stubb and Flask kill a Right Whale; and Then Have a Talk over Him.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-13.htm.html#pgepubid00078"
+    },
+    {
+      "title": "CHAPTER 74. The Sperm Whale’s Head—Contrasted View.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00079"
+    },
+    {
+      "title": "CHAPTER 75. The Right Whale’s Head—Contrasted View.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00080"
+    },
+    {
+      "title": "CHAPTER 76. The Battering-Ram.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00081"
+    },
+    {
+      "title": "CHAPTER 77. The Great Heidelburgh Tun.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00082"
+    },
+    {
+      "title": "CHAPTER 78. Cistern and Buckets.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00083"
+    },
+    {
+      "title": "CHAPTER 79. The Prairie.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00084"
+    },
+    {
+      "title": "CHAPTER 80. The Nut.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00085"
+    },
+    {
+      "title": "CHAPTER 81. The Pequod Meets The Virgin.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-14.htm.html#pgepubid00086"
+    },
+    {
+      "title": "CHAPTER 82. The Honor and Glory of Whaling.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00087"
+    },
+    {
+      "title": "CHAPTER 83. Jonah Historically Regarded.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00088"
+    },
+    {
+      "title": "CHAPTER 84. Pitchpoling.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00089"
+    },
+    {
+      "title": "CHAPTER 85. The Fountain.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00090"
+    },
+    {
+      "title": "CHAPTER 86. The Tail.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00091"
+    },
+    {
+      "title": "CHAPTER 87. The Grand Armada.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-15.htm.html#pgepubid00092"
+    },
+    {
+      "title": "CHAPTER 88. Schools and Schoolmasters.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00093"
+    },
+    {
+      "title": "CHAPTER 89. Fast-Fish and Loose-Fish.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00094"
+    },
+    {
+      "title": "CHAPTER 90. Heads or Tails.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00095"
+    },
+    {
+      "title": "CHAPTER 91. The Pequod Meets The Rose-Bud.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00096"
+    },
+    {
+      "title": "CHAPTER 92. Ambergris.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00097"
+    },
+    {
+      "title": "CHAPTER 93. The Castaway.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-16.htm.html#pgepubid00098"
+    },
+    {
+      "title": "CHAPTER 94. A Squeeze of the Hand.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00099"
+    },
+    {
+      "title": "CHAPTER 95. The Cassock.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00100"
+    },
+    {
+      "title": "CHAPTER 96. The Try-Works.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00101"
+    },
+    {
+      "title": "CHAPTER 97. The Lamp.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00102"
+    },
+    {
+      "title": "CHAPTER 98. Stowing Down and Clearing Up.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00103"
+    },
+    {
+      "title": "CHAPTER 99. The Doubloon.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00104"
+    },
+    {
+      "title": "CHAPTER 100. Leg and Arm.",
+      "children": [
+        {
+          "title": "The Pequod, of Nantucket, Meets the Samuel Enderby, of London.",
+          "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00106"
+        }
+      ],
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-17.htm.html#pgepubid00105"
+    },
+    {
+      "title": "CHAPTER 101. The Decanter.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00107"
+    },
+    {
+      "title": "CHAPTER 102. A Bower in the Arsacides.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00108"
+    },
+    {
+      "title": "CHAPTER 103. Measurement of The Whale’s Skeleton.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00109"
+    },
+    {
+      "title": "CHAPTER 104. The Fossil Whale.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00110"
+    },
+    {
+      "title": "CHAPTER 105. Does the Whale’s Magnitude Diminish?—Will He Perish?",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00111"
+    },
+    {
+      "title": "CHAPTER 106. Ahab’s Leg.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-18.htm.html#pgepubid00112"
+    },
+    {
+      "title": "CHAPTER 107. The Carpenter.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00113"
+    },
+    {
+      "title": "CHAPTER 108. Ahab and the Carpenter.",
+      "children": [
+        {
+          "title": "The Deck—First Night Watch.",
+          "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00115"
+        }
+      ],
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00114"
+    },
+    {
+      "title": "CHAPTER 109. Ahab and Starbuck in the Cabin.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00116"
+    },
+    {
+      "title": "CHAPTER 110. Queequeg in His Coffin.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00117"
+    },
+    {
+      "title": "CHAPTER 111. The Pacific.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00118"
+    },
+    {
+      "title": "CHAPTER 112. The Blacksmith.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00119"
+    },
+    {
+      "title": "CHAPTER 113. The Forge.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-19.htm.html#pgepubid00120"
+    },
+    {
+      "title": "CHAPTER 114. The Gilder.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00121"
+    },
+    {
+      "title": "CHAPTER 115. The Pequod Meets The Bachelor.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00122"
+    },
+    {
+      "title": "CHAPTER 116. The Dying Whale.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00123"
+    },
+    {
+      "title": "CHAPTER 117. The Whale Watch.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00124"
+    },
+    {
+      "title": "CHAPTER 118. The Quadrant.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00125"
+    },
+    {
+      "title": "CHAPTER 119. The Candles.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00126"
+    },
+    {
+      "title": "CHAPTER 120. The Deck Towards the End of the First Night Watch.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00127"
+    },
+    {
+      "title": "CHAPTER 121. Midnight.—The Forecastle Bulwarks.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00128"
+    },
+    {
+      "title": "CHAPTER 122. Midnight Aloft.—Thunder and Lightning.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00129"
+    },
+    {
+      "title": "CHAPTER 123. The Musket.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-20.htm.html#pgepubid00130"
+    },
+    {
+      "title": "CHAPTER 124. The Needle.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00131"
+    },
+    {
+      "title": "CHAPTER 125. The Log and Line.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00132"
+    },
+    {
+      "title": "CHAPTER 126. The Life-Buoy.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00133"
+    },
+    {
+      "title": "CHAPTER 127. The Deck.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00134"
+    },
+    {
+      "title": "CHAPTER 128. The Pequod Meets The Rachel.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00135"
+    },
+    {
+      "title": "CHAPTER 129. The Cabin.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00136"
+    },
+    {
+      "title": "CHAPTER 130. The Hat.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-21.htm.html#pgepubid00137"
+    },
+    {
+      "title": "CHAPTER 131. The Pequod Meets The Delight.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-22.htm.html#pgepubid00138"
+    },
+    {
+      "title": "CHAPTER 132. The Symphony.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-22.htm.html#pgepubid00139"
+    },
+    {
+      "title": "CHAPTER 133. The Chase—First Day.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-22.htm.html#pgepubid00140"
+    },
+    {
+      "title": "CHAPTER 134. The Chase—Second Day.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-22.htm.html#pgepubid00141"
+    },
+    {
+      "title": "CHAPTER 135. The Chase.—Third Day.",
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-23.htm.html#pgepubid00142"
+    },
+    {
+      "title": "Epilogue",
+      "children": [
+        {
+          "title": "“AND I ONLY AM ESCAPED ALONE TO TELL THEE” Job.",
+          "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-23.htm.html#pgepubid00144"
+        }
+      ],
+      "href": "OEBPS/@public@vhost@g@gutenberg@html@files@2701@2701-h@2701-h-23.htm.html#pgepubid00143"
+    }
+  ],
+  "landmarks": [
+    {
+      "title": "Cover",
+      "href": "OEBPS/wrap0000.html"
+    }
+  ]
+}

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -33,6 +33,9 @@ export default class Epub {
   constructor(
     public readonly fetcher: Fetcher,
     private readonly containerXmlPath: string,
+    // whether the resulting manifest should contain relative or absolute hrefs
+    // defaults to relative
+    public readonly useRelativeHrefs: boolean,
     // used to resolve items relative to the opf file
     public readonly opfPath: string,
     public readonly container: Container,
@@ -52,12 +55,14 @@ export default class Epub {
     containerXmlPath: string,
     fetcher: Fetcher,
     {
+      useRelativeHrefs,
       decryptor,
       isAxisNow,
     }: {
+      useRelativeHrefs: boolean;
       decryptor?: Decryptor;
       isAxisNow?: boolean;
-    } = { decryptor: undefined, isAxisNow: false }
+    } = { useRelativeHrefs: true, decryptor: undefined, isAxisNow: false }
   ) {
     const container = Epub.parseContainer(
       await fetcher.getFileStr(containerXmlPath)
@@ -126,6 +131,7 @@ export default class Epub {
     return new Epub(
       fetcher,
       containerXmlPath,
+      useRelativeHrefs,
       opfPath,
       container,
       opf,

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -12,6 +12,7 @@ import { WebpubManifest } from './WebpubManifestTypes/WebpubManifest';
 import { epubToManifest } from './convert';
 import Decryptor from '@nypl-simplified-packages/axisnow-access-control-web';
 import Fetcher from './Fetcher';
+import { getEncryptionInfo } from './convert/encryption';
 
 /**
  * This class represents a complete EPUB. It is abstract
@@ -58,6 +59,7 @@ export default class Epub {
       isAxisNow?: boolean;
     } = { decryptor: undefined, isAxisNow: false }
   ) {
+    console.log('BUILDING');
     const container = Epub.parseContainer(
       await fetcher.getFileStr(containerXmlPath)
     );
@@ -65,32 +67,62 @@ export default class Epub {
     const opfPath = fetcher.getOpfPath(relativeOpfPath);
     const opf = await Epub.parseOpf(await fetcher.getFileStr(opfPath));
 
-    const relativeNcxPath = Epub.getNcxHref(opf);
-    const ncxPath = relativeNcxPath
-      ? fetcher.resolvePath(opfPath, relativeNcxPath)
-      : undefined;
-
-    const ncxBuffer = ncxPath
-      ? await fetcher.getArrayBuffer(ncxPath)
-      : undefined;
-    const ncxStr = await Epub.decryptStr(ncxBuffer, decryptor);
-    const ncx = Epub.parseNcx(ncxStr);
-
-    const relativeNavDocPath = Epub.getNavDocHref(opf);
-    const navDocPath = relativeNavDocPath
-      ? fetcher.resolvePath(opfPath, relativeNavDocPath)
-      : undefined;
-    const navDocBuffer = navDocPath
-      ? await fetcher.getArrayBuffer(navDocPath)
-      : undefined;
-    const navDocStr = await Epub.decryptStr(navDocBuffer, decryptor);
-    const navDoc = Epub.parseNavDoc(navDocStr);
-
     // if there is no encryption path, the encryptionDoc will be undefined
     // and the EPUB will be assumed unencrypted.
     const encryptionPath = fetcher.getEncryptionPath(containerXmlPath);
     const encryptionStr = await fetcher.getOptionalFileStr(encryptionPath);
     const encryptionDoc = Epub.parseEncryptionDoc(encryptionStr);
+
+    // ncx file
+    const relativeNcxPath = Epub.getNcxHref(opf);
+    const ncxPath = relativeNcxPath
+      ? fetcher.resolvePath(opfPath, relativeNcxPath)
+      : undefined;
+
+    let ncx: NCX | undefined = undefined;
+    if (ncxPath) {
+      // it is encrypted if there is an entry for it in encryption.xml
+      const ncxIsEncrypted = !!getEncryptionInfo(
+        encryptionDoc,
+        ncxPath,
+        isAxisNow
+      );
+      if (ncxIsEncrypted) {
+        const ncxBuffer = ncxPath
+          ? await fetcher.getArrayBuffer(ncxPath)
+          : undefined;
+        const ncxStr = await Epub.decryptStr(ncxBuffer, decryptor);
+        ncx = Epub.parseNcx(ncxStr);
+      } else {
+        const ncxStr = await fetcher.getFileStr(ncxPath);
+        ncx = Epub.parseNcx(ncxStr);
+      }
+    }
+
+    // navdoc file
+    const relativeNavDocPath = Epub.getNavDocHref(opf);
+    const navDocPath = relativeNavDocPath
+      ? fetcher.resolvePath(opfPath, relativeNavDocPath)
+      : undefined;
+
+    let navDoc: Document | undefined = undefined;
+    if (navDocPath) {
+      const isNavDocEncrypted = !!getEncryptionInfo(
+        encryptionDoc,
+        navDocPath,
+        isAxisNow
+      );
+      if (isNavDocEncrypted) {
+        const navDocBuffer = navDocPath
+          ? await fetcher.getArrayBuffer(navDocPath)
+          : undefined;
+        const navDocStr = await Epub.decryptStr(navDocBuffer, decryptor);
+        navDoc = Epub.parseNavDoc(navDocStr);
+      } else {
+        const navDocStr = await fetcher.getFileStr(navDocPath);
+        navDoc = Epub.parseNavDoc(navDocStr);
+      }
+    }
 
     return new Epub(
       fetcher,
@@ -137,6 +169,14 @@ export default class Epub {
   get webpubManifest(): Promise<WebpubManifest> {
     return epubToManifest(this);
   }
+
+  static async getNcx(
+    opf: OPF,
+    opfPath: string,
+    encryptionDoc: Encryption | undefined,
+    fetcher: Fetcher,
+    isAxisNow: boolean | undefined
+  ) {}
 
   ///////////////////
   // METHODS FOR DESERIALIZING VALUES INTO IN-MEMORY CLASSES
@@ -267,6 +307,10 @@ export default class Epub {
   ): Promise<ArrayBuffer> {
     if (!decryptor) return buffer;
     return await decryptor.decrypt(new Uint8Array(buffer));
+  }
+
+  getLinkEncryption(relativePath: string) {
+    return getEncryptionInfo(this.encryptionDoc, relativePath, this.isAxisNow);
   }
 
   ///////////////////

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -170,14 +170,6 @@ export default class Epub {
     return epubToManifest(this);
   }
 
-  static async getNcx(
-    opf: OPF,
-    opfPath: string,
-    encryptionDoc: Encryption | undefined,
-    fetcher: Fetcher,
-    isAxisNow: boolean | undefined
-  ) {}
-
   ///////////////////
   // METHODS FOR DESERIALIZING VALUES INTO IN-MEMORY CLASSES
   ///////////////////

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -59,7 +59,6 @@ export default class Epub {
       isAxisNow?: boolean;
     } = { decryptor: undefined, isAxisNow: false }
   ) {
-    console.log('BUILDING');
     const container = Epub.parseContainer(
       await fetcher.getFileStr(containerXmlPath)
     );

--- a/src/Fetcher.ts
+++ b/src/Fetcher.ts
@@ -20,6 +20,8 @@ export default abstract class Fetcher {
   abstract resolvePath(from: string, to: string): string;
   // returns a path relative to the EPUB root
   abstract resolveRelativePath(from: string, to: string): string;
+  // resolves either a relative or absolute href depending on the flag
+  abstract resolveHref(from: string, to: string, relative: boolean): string;
 
   // this differs per fetcher because path.resolve(...) and new URL(...) don't work the same way
   abstract getOpfPath(relativeOpfPath: string): string;

--- a/src/LocalFetcher.ts
+++ b/src/LocalFetcher.ts
@@ -29,6 +29,12 @@ export default class LocalFetcher extends Fetcher {
     const fullPath = this.resolvePath(from, to);
     return path.relative(this.folderPath, fullPath);
   }
+  resolveHref(from: string, to: string, relative: boolean) {
+    return relative
+      ? this.resolveRelativePath(from, to)
+      : this.resolvePath(from, to);
+  }
+
   async getArrayBuffer(path: string): Promise<ArrayBuffer> {
     const buffer = fs.readFileSync(path, null);
     return Promise.resolve(buffer);

--- a/src/RemoteFetcher.ts
+++ b/src/RemoteFetcher.ts
@@ -55,6 +55,11 @@ export default class RemoteFetcher extends Fetcher {
   resolveRelativePath(from: string, to: string): string {
     return this.resolvePath(from, to).replace(this.folderPath, '');
   }
+  resolveHref(from: string, to: string, relative: boolean) {
+    return relative
+      ? this.resolveRelativePath(from, to)
+      : this.resolvePath(from, to);
+  }
 
   async getImageDimensions(relativePath: string) {
     const url = this.resolvePath(this.folderPath, relativePath);

--- a/src/__tests__/RemoteExplodedEpub.test.ts
+++ b/src/__tests__/RemoteExplodedEpub.test.ts
@@ -3,6 +3,7 @@ import RemoteFetcher from '../RemoteFetcher';
 import { baseUrl } from './constants';
 import mobyEpub2Manifest from './stubs/moby-epub2';
 import mobyEpub3Manifest from './stubs/moby-epub3';
+import mobyAbsoluteHrefs from './stubs/moby-epub3-absolute-hrefs';
 import { expectSelectively, expectSelectivelyArr } from './utils';
 
 const MobyEpub2Href = `${baseUrl}/samples/moby-epub2-exploded/META-INF/container.xml`;
@@ -112,5 +113,61 @@ describe('Moby EPUB 3 Exploded', () => {
   it('extracts toc', async () => {
     const manifest = await getManifest();
     expect(manifest.toc).toEqual(mobyEpub3Manifest.toc);
+  });
+});
+
+describe('Absolute Hrefs', () => {
+  async function getManifest() {
+    const fetcher = new RemoteFetcher(MobyEpub3Href);
+    const epub = await Epub.build(MobyEpub3Href, fetcher, {
+      useRelativeHrefs: false,
+    });
+    const manifest = await epub.webpubManifest;
+    return manifest;
+  }
+
+  it('context', async () => {
+    const manifest = await getManifest();
+    expect(manifest['@context']).toBe(mobyAbsoluteHrefs['@context']);
+  });
+
+  it('extracts correct metadata', async () => {
+    const manifest = await getManifest();
+
+    expect(manifest.metadata.author).toBe(
+      mobyAbsoluteHrefs.metadata.author.name
+    );
+    expectSelectively(
+      manifest.metadata,
+      mobyAbsoluteHrefs.metadata,
+      'title',
+      'language'
+    );
+  });
+
+  it('extracts reading order', async () => {
+    const manifest = await getManifest();
+    expectSelectivelyArr(
+      manifest.readingOrder,
+      mobyAbsoluteHrefs.readingOrder,
+      'href',
+      'type'
+    );
+  });
+
+  it('extracts resources', async () => {
+    const manifest = await getManifest();
+    expectSelectivelyArr(
+      manifest.resources as any,
+      mobyAbsoluteHrefs.resources,
+      'href',
+      'type',
+      'type'
+    );
+  });
+
+  it('extracts toc', async () => {
+    const manifest = await getManifest();
+    expect(manifest.toc).toEqual(mobyAbsoluteHrefs.toc);
   });
 });

--- a/src/__tests__/navdoc.test.tsx
+++ b/src/__tests__/navdoc.test.tsx
@@ -124,6 +124,17 @@ describe('listItemToLink', () => {
     });
   });
 
+  it('extracts absolute link from basic list item', () => {
+    expect(
+      listItemToLink({ ...epub, useRelativeHrefs: false } as Epub)(
+        basicListItem
+      )
+    ).toEqual({
+      title: 'Basic Title',
+      href: 'https://domain.com/OPS/basic-href',
+    });
+  });
+
   it('extracts link from nested list item', () => {
     expect(listItemToLink(epub)(listItemWithoutSpan)).toEqual({
       title: 'Parent',
@@ -131,6 +142,21 @@ describe('listItemToLink', () => {
       children: [
         { title: 'Child 1', href: 'OPS/child-1-href' },
         { title: 'Child 2', href: 'OPS/child-2-href' },
+      ],
+    });
+  });
+
+  it('extracts absolute link from nested list item', () => {
+    expect(
+      listItemToLink({ ...epub, useRelativeHrefs: false } as Epub)(
+        listItemWithoutSpan
+      )
+    ).toEqual({
+      title: 'Parent',
+      href: 'https://domain.com/OPS/parent-href',
+      children: [
+        { title: 'Child 1', href: 'https://domain.com/OPS/child-1-href' },
+        { title: 'Child 2', href: 'https://domain.com/OPS/child-2-href' },
       ],
     });
   });

--- a/src/__tests__/navdoc.test.tsx
+++ b/src/__tests__/navdoc.test.tsx
@@ -111,6 +111,9 @@ describe('listItemToLink', () => {
       resolveRelativePath: (from: string, to: string) => {
         return `OPS/${to}`;
       },
+      resolveHref: (from: string, to: string, relative: boolean = true) => {
+        return relative ? `OPS/${to}` : `https://domain.com/OPS/${to}`;
+      },
     },
   } as Epub;
 

--- a/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
+++ b/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
@@ -1,0 +1,1229 @@
+const mobyEpub3Manifest = {
+  '@context': 'https://readium.org/webpub-manifest/context.jsonld',
+  metadata: {
+    '@type': 'http://schema.org/Book',
+    title: 'Moby-Dick',
+    identifier: 'code.google.com.epub-samples.moby-dick-basic',
+    author: {
+      name: 'Herman Melville',
+      sortAs: 'MELVILLE, HERMAN',
+    },
+    contributor: {
+      name: 'Dave Cramer',
+      role: 'mrk',
+    },
+    publisher: 'Harper & Brothers, Publishers',
+    language: 'en-US',
+    modified: '2021-05-26T02:51:07.706Z',
+    rights:
+      'This work is shared with the public using the Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0) license.',
+    'title-type': 'main',
+    'file-as': 'MELVILLE, HERMAN',
+    role: 'mrk',
+    'dcterms:modified': '2012-01-18T12:47:00Z',
+    'cc:attributionURL': 'http://code.google.com/p/epub-samples/',
+  },
+  readingOrder: [
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/titlepage.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc-short.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/preface_001.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/introduction_001.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/epigraph_001.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_001.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_002.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_003.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_004.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_005.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_006.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_007.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_008.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_009.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_010.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_011.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_012.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_013.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_014.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_015.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_016.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_017.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_018.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_019.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_020.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_021.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_022.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_023.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_024.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_025.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_026.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_027.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_028.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_029.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_030.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_031.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_032.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_033.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_034.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_035.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_036.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_037.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_038.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_039.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_040.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_041.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_042.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_043.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_044.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_045.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_046.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_047.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_048.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_049.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_050.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_051.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_052.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_053.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_054.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_055.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_056.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_057.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_058.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_059.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_060.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_061.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_062.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_063.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_064.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_065.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_066.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_067.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_068.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_069.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_070.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_071.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_072.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_073.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_074.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_075.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_076.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_077.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_078.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_079.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_080.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_081.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_082.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_083.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_084.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_085.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_086.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_087.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_088.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_089.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_090.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_091.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_092.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_093.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_094.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_095.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_096.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_097.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_098.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_099.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_100.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_101.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_102.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_103.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_104.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_105.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_106.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_107.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_108.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_109.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_110.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_111.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_112.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_113.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_114.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_115.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_116.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_117.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_118.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_119.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_120.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_121.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_122.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_123.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_124.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_125.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_126.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_127.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_128.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_129.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_130.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_131.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_132.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_133.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_134.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_135.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_136.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/copyright.xhtml',
+    },
+  ],
+  resources: [
+    {
+      type: 'application/vnd.ms-opentype',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/fonts/STIXGeneral.otf',
+    },
+    {
+      type: 'application/vnd.ms-opentype',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/fonts/STIXGeneralItalic.otf',
+    },
+    {
+      type: 'application/vnd.ms-opentype',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/fonts/STIXGeneralBol.otf',
+    },
+    {
+      type: 'application/vnd.ms-opentype',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/fonts/STIXGeneralBolIta.otf',
+    },
+    {
+      type: 'application/xhtml+xml',
+      rel: 'contents',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/cover.xhtml',
+    },
+    {
+      type: 'image/jpeg',
+      height: 902,
+      width: 646,
+      rel: 'cover',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/images/9780316000000.jpg',
+    },
+    {
+      type: 'text/css',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/css/stylesheet.css',
+    },
+    {
+      type: 'image/jpeg',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/images/Moby-Dick_FE_title_page.jpg',
+      width: 840,
+      height: 1380,
+    },
+  ],
+  toc: [
+    {
+      title: 'Moby-Dick',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/titlepage.xhtml',
+    },
+    {
+      title: 'Original Transcriber’s Notes:',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/preface_001.xhtml',
+    },
+    {
+      title: 'ETYMOLOGY.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/introduction_001.xhtml',
+    },
+    {
+      title: 'EXTRACTS (Supplied by a Sub-Sub-Librarian).',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/epigraph_001.xhtml',
+    },
+    {
+      title: 'Chapter 1. Loomings.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_001.xhtml',
+    },
+    {
+      title: 'Chapter 2. The Carpet-Bag.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_002.xhtml',
+    },
+    {
+      title: 'Chapter 3. The Spouter-Inn.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_003.xhtml',
+    },
+    {
+      title: 'Chapter 4. The Counterpane.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_004.xhtml',
+    },
+    {
+      title: 'Chapter 5. Breakfast.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_005.xhtml',
+    },
+    {
+      title: 'Chapter 6. The Street.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_006.xhtml',
+    },
+    {
+      title: 'Chapter 7. The Chapel.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_007.xhtml',
+    },
+    {
+      title: 'Chapter 8. The Pulpit.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_008.xhtml',
+    },
+    {
+      title: 'Chapter 9. The Sermon.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_009.xhtml',
+    },
+    {
+      title: 'Chapter 10. A Bosom Friend.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_010.xhtml',
+    },
+    {
+      title: 'Chapter 11. Nightgown.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_011.xhtml',
+    },
+    {
+      title: 'Chapter 12. Biographical.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_012.xhtml',
+    },
+    {
+      title: 'Chapter 13. Wheelbarrow.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_013.xhtml',
+    },
+    {
+      title: 'Chapter 14. Nantucket.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_014.xhtml',
+    },
+    {
+      title: 'Chapter 15. Chowder.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_015.xhtml',
+    },
+    {
+      title: 'Chapter 16. The Ship.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_016.xhtml',
+    },
+    {
+      title: 'Chapter 17. The Ramadan.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_017.xhtml',
+    },
+    {
+      title: 'Chapter 18. His Mark.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_018.xhtml',
+    },
+    {
+      title: 'Chapter 19. The Prophet.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_019.xhtml',
+    },
+    {
+      title: 'Chapter 20. All Astir.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_020.xhtml',
+    },
+    {
+      title: 'Chapter 21. Going Aboard.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_021.xhtml',
+    },
+    {
+      title: 'Chapter 22. Merry Christmas.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_022.xhtml',
+    },
+    {
+      title: 'Chapter 23. The Lee Shore.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_023.xhtml',
+    },
+    {
+      title: 'Chapter 24. The Advocate.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_024.xhtml',
+    },
+    {
+      title: 'Chapter 25. Postscript.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_025.xhtml',
+    },
+    {
+      title: 'Chapter 26. Knights and Squires.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_026.xhtml',
+    },
+    {
+      title: 'Chapter 27. Knights and Squires.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_027.xhtml',
+    },
+    {
+      title: 'Chapter 28. Ahab.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_028.xhtml',
+    },
+    {
+      title: 'Chapter 29. Enter Ahab; to Him, Stubb.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_029.xhtml',
+    },
+    {
+      title: 'Chapter 30. The Pipe.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_030.xhtml',
+    },
+    {
+      title: 'Chapter 31. Queen Mab.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_031.xhtml',
+    },
+    {
+      title: 'Chapter 32. Cetology.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_032.xhtml',
+    },
+    {
+      title: 'Chapter 33. The Specksnyder.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_033.xhtml',
+    },
+    {
+      title: 'Chapter 34. The Cabin-Table.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_034.xhtml',
+    },
+    {
+      title: 'Chapter 35. The Mast-Head.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_035.xhtml',
+    },
+    {
+      title: 'Chapter 36. The Quarter-Deck.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_036.xhtml',
+    },
+    {
+      title: 'Chapter 37. Sunset.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_037.xhtml',
+    },
+    {
+      title: 'Chapter 38. Dusk.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_038.xhtml',
+    },
+    {
+      title: 'Chapter 39. First Night Watch.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_039.xhtml',
+    },
+    {
+      title: 'Chapter 40. Midnight, Forecastle.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_040.xhtml',
+    },
+    {
+      title: 'Chapter 41. Moby Dick.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_041.xhtml',
+    },
+    {
+      title: 'Chapter 42. The Whiteness of The Whale.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_042.xhtml',
+    },
+    {
+      title: 'Chapter 43. Hark!',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_043.xhtml',
+    },
+    {
+      title: 'Chapter 44. The Chart.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_044.xhtml',
+    },
+    {
+      title: 'Chapter 45. The Affidavit.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_045.xhtml',
+    },
+    {
+      title: 'Chapter 46. Surmises.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_046.xhtml',
+    },
+    {
+      title: 'Chapter 47. The Mat-Maker.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_047.xhtml',
+    },
+    {
+      title: 'Chapter 48. The First Lowering.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_048.xhtml',
+    },
+    {
+      title: 'Chapter 49. The Hyena.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_049.xhtml',
+    },
+    {
+      title: 'Chapter 50. Ahab’s Boat and Crew. Fedallah.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_050.xhtml',
+    },
+    {
+      title: 'Chapter 51. The Spirit-Spout.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_051.xhtml',
+    },
+    {
+      title: 'Chapter 52. The Albatross.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_052.xhtml',
+    },
+    {
+      title: 'Chapter 53. The Gam.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_053.xhtml',
+    },
+    {
+      title: 'Chapter 54. The Town-Ho’s Story.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_054.xhtml',
+    },
+    {
+      title: 'Chapter 55. Of the Monstrous Pictures of Whales.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_055.xhtml',
+    },
+    {
+      title:
+        'Chapter 56. Of the Less Erroneous Pictures of Whales, and the True',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_056.xhtml',
+    },
+    {
+      title:
+        'Chapter 57. Of Whales in Paint; in Teeth; in Wood; in Sheet-Iron; in',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_057.xhtml',
+    },
+    {
+      title: 'Chapter 58. Brit.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_058.xhtml',
+    },
+    {
+      title: 'Chapter 59. Squid.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_059.xhtml',
+    },
+    {
+      title: 'Chapter 60. The Line.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_060.xhtml',
+    },
+    {
+      title: 'Chapter 61. Stubb Kills a Whale.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_061.xhtml',
+    },
+    {
+      title: 'Chapter 62. The Dart.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_062.xhtml',
+    },
+    {
+      title: 'Chapter 63. The Crotch.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_063.xhtml',
+    },
+    {
+      title: 'Chapter 64. Stubb’s Supper.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_064.xhtml',
+    },
+    {
+      title: 'Chapter 65. The Whale as a Dish.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_065.xhtml',
+    },
+    {
+      title: 'Chapter 66. The Shark Massacre.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_066.xhtml',
+    },
+    {
+      title: 'Chapter 67. Cutting In.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_067.xhtml',
+    },
+    {
+      title: 'Chapter 68. The Blanket.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_068.xhtml',
+    },
+    {
+      title: 'Chapter 69. The Funeral.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_069.xhtml',
+    },
+    {
+      title: 'Chapter 70. The Sphynx.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_070.xhtml',
+    },
+    {
+      title: 'Chapter 71. The Jeroboam’s Story.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_071.xhtml',
+    },
+    {
+      title: 'Chapter 72. The Monkey-Rope.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_072.xhtml',
+    },
+    {
+      title:
+        'Chapter 73. Stubb and Flask Kill a Right Whale; and Then Have a Talk',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_073.xhtml',
+    },
+    {
+      title: 'Chapter 74. The Sperm Whale’s Head—Contrasted View.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_074.xhtml',
+    },
+    {
+      title: 'Chapter 75. The Right Whale’s Head—Contrasted View.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_075.xhtml',
+    },
+    {
+      title: 'Chapter 76. The Battering-Ram.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_076.xhtml',
+    },
+    {
+      title: 'Chapter 77. The Great Heidelburgh Tun.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_077.xhtml',
+    },
+    {
+      title: 'Chapter 78. Cistern and Buckets.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_078.xhtml',
+    },
+    {
+      title: 'Chapter 79. The Prairie.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_079.xhtml',
+    },
+    {
+      title: 'Chapter 80. The Nut.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_080.xhtml',
+    },
+    {
+      title: 'Chapter 81. The Pequod Meets The Virgin.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_081.xhtml',
+    },
+    {
+      title: 'Chapter 82. The Honour and Glory of Whaling.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_082.xhtml',
+    },
+    {
+      title: 'Chapter 83. Jonah Historically Regarded.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_083.xhtml',
+    },
+    {
+      title: 'Chapter 84. Pitchpoling.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_084.xhtml',
+    },
+    {
+      title: 'Chapter 85. The Fountain.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_085.xhtml',
+    },
+    {
+      title: 'Chapter 86. The Tail.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_086.xhtml',
+    },
+    {
+      title: 'Chapter 87. The Grand Armada.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_087.xhtml',
+    },
+    {
+      title: 'Chapter 88. Schools and Schoolmasters.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_088.xhtml',
+    },
+    {
+      title: 'Chapter 89. Fast-Fish and Loose-Fish.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_089.xhtml',
+    },
+    {
+      title: 'Chapter 90. Heads or Tails.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_090.xhtml',
+    },
+    {
+      title: 'Chapter 91. The Pequod Meets The Rose-Bud.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_091.xhtml',
+    },
+    {
+      title: 'Chapter 92. Ambergris.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_092.xhtml',
+    },
+    {
+      title: 'Chapter 93. The Castaway.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_093.xhtml',
+    },
+    {
+      title: 'Chapter 94. A Squeeze of the Hand.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_094.xhtml',
+    },
+    {
+      title: 'Chapter 95. The Cassock.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_095.xhtml',
+    },
+    {
+      title: 'Chapter 96. The Try-Works.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_096.xhtml',
+    },
+    {
+      title: 'Chapter 97. The Lamp.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_097.xhtml',
+    },
+    {
+      title: 'Chapter 98. Stowing Down and Clearing Up.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_098.xhtml',
+    },
+    {
+      title: 'Chapter 99. The Doubloon.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_099.xhtml',
+    },
+    {
+      title: 'Chapter 100. Leg and Arm.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_100.xhtml',
+    },
+    {
+      title: 'Chapter 101. The Decanter.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_101.xhtml',
+    },
+    {
+      title: 'Chapter 102. A Bower in the Arsacides.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_102.xhtml',
+    },
+    {
+      title: 'Chapter 103. Measurement of The Whale’s Skeleton.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_103.xhtml',
+    },
+    {
+      title: 'Chapter 104. The Fossil Whale.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_104.xhtml',
+    },
+    {
+      title:
+        'Chapter 105. Does the Whale’s Magnitude Diminish?—Will He Perish?',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_105.xhtml',
+    },
+    {
+      title: 'Chapter 106. Ahab’s Leg.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_106.xhtml',
+    },
+    {
+      title: 'Chapter 107. The Carpenter.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_107.xhtml',
+    },
+    {
+      title: 'Chapter 108. Ahab and the Carpenter.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_108.xhtml',
+    },
+    {
+      title: 'Chapter 109. Ahab and Starbuck in the Cabin.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_109.xhtml',
+    },
+    {
+      title: 'Chapter 110. Queequeg in His Coffin.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_110.xhtml',
+    },
+    {
+      title: 'Chapter 111. The Pacific.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_111.xhtml',
+    },
+    {
+      title: 'Chapter 112. The Blacksmith.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_112.xhtml',
+    },
+    {
+      title: 'Chapter 113. The Forge.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_113.xhtml',
+    },
+    {
+      title: 'Chapter 114. The Gilder.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_114.xhtml',
+    },
+    {
+      title: 'Chapter 115. The Pequod Meets The Bachelor.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_115.xhtml',
+    },
+    {
+      title: 'Chapter 116. The Dying Whale.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_116.xhtml',
+    },
+    {
+      title: 'Chapter 117. The Whale Watch.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_117.xhtml',
+    },
+    {
+      title: 'Chapter 118. The Quadrant.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_118.xhtml',
+    },
+    {
+      title: 'Chapter 119. The Candles.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_119.xhtml',
+    },
+    {
+      title: 'Chapter 120. The Deck Towards the End of the First Night Watch.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_120.xhtml',
+    },
+    {
+      title: 'Chapter 121. Midnight.—The Forecastle Bulwarks.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_121.xhtml',
+    },
+    {
+      title: 'Chapter 122. Midnight Aloft.—Thunder and Lightning.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_122.xhtml',
+    },
+    {
+      title: 'Chapter 123. The Musket.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_123.xhtml',
+    },
+    {
+      title: 'Chapter 124. The Needle.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_124.xhtml',
+    },
+    {
+      title: 'Chapter 125. The Log and Line.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_125.xhtml',
+    },
+    {
+      title: 'Chapter 126. The Life-Buoy.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_126.xhtml',
+    },
+    {
+      title: 'Chapter 127. The Deck.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_127.xhtml',
+    },
+    {
+      title: 'Chapter 128. The Pequod Meets The Rachel.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_128.xhtml',
+    },
+    {
+      title: 'Chapter 129. The Cabin.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_129.xhtml',
+    },
+    {
+      title: 'Chapter 130. The Hat.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_130.xhtml',
+    },
+    {
+      title: 'Chapter 131. The Pequod Meets The Delight.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_131.xhtml',
+    },
+    {
+      title: 'Chapter 132. The Symphony.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_132.xhtml',
+    },
+    {
+      title: 'Chapter 133. The Chase—First Day.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_133.xhtml',
+    },
+    {
+      title: 'Chapter 134. The Chase—Second Day.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_134.xhtml',
+    },
+    {
+      title: 'Chapter 135. The Chase.—Third Day.',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_135.xhtml',
+    },
+    {
+      title: 'Epilogue',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_136.xhtml',
+    },
+    {
+      title: 'Copyright Page',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/copyright.xhtml',
+    },
+  ],
+  landmarks: [
+    {
+      title: 'Table of Contents',
+      rel: 'toc',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc.xhtml#toc',
+    },
+    {
+      title: 'Begin Reading',
+      rel: 'bodymatter',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/chapter_001.xhtml',
+    },
+    {
+      title: 'Copyright Page',
+      rel: 'copyright-page',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/copyright.xhtml',
+    },
+  ],
+};
+
+export default mobyEpub3Manifest;

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -1,3 +1,5 @@
+import { Encryption } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption';
+import { EncryptedData } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption-data';
 import { AxisNowEncryptionScheme } from '../constants';
 import Epub from '../Epub';
 import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtension';
@@ -6,8 +8,12 @@ import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtensio
  * Adds encryption information to the resource link if there is any detected for this
  * link in the epub.encryptionDoc
  */
-export default function getLinkEncryption(epub: Epub, relativePath: string) {
-  const encryptionData = epub.encryptionDoc?.EncryptedData.find(
+export function getEncryptionInfo(
+  encryptionDoc: Encryption | undefined,
+  relativePath: string,
+  isAxisNow: boolean | undefined
+) {
+  const encryptionData = encryptionDoc?.EncryptedData.find(
     (data) => data.CipherData.CipherReference.URI === relativePath
   );
   const algorithm = encryptionData?.EncryptionMethod.Algorithm;
@@ -20,7 +26,7 @@ export default function getLinkEncryption(epub: Epub, relativePath: string) {
    * using.
    */
   if (algorithm) {
-    if (epub.isAxisNow) {
+    if (isAxisNow) {
       encryption = {
         algorithm,
         scheme: AxisNowEncryptionScheme,

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -1,7 +1,5 @@
 import { Encryption } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption';
-import { EncryptedData } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/encryption-data';
 import { AxisNowEncryptionScheme } from '../constants';
-import Epub from '../Epub';
 import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtension';
 
 /**

--- a/src/convert/navdoc.ts
+++ b/src/convert/navdoc.ts
@@ -76,10 +76,14 @@ export const listItemToLink =
     if (typeof href !== 'string') {
       throw new Error(`TOC List item missing href: ${listItem.toString()}`);
     }
-    const relativePath = epub.fetcher.resolveRelativePath(epub.opfPath, href);
+    const resolvedHref = epub.fetcher.resolveHref(
+      epub.opfPath,
+      href,
+      epub.useRelativeHrefs
+    );
     const link: ReadiumLink = {
       title: anchorTitle,
-      href: relativePath,
+      href: resolvedHref,
     };
     // add children if there are any
     if (children && children.length > 0) link.children = children;

--- a/src/convert/ncx.ts
+++ b/src/convert/ncx.ts
@@ -28,7 +28,7 @@ export const navPointToLink =
     }
     const link: ReadiumLink = {
       title: point.NavLabel.Text,
-      href: epub.fetcher.resolveRelativePath(epub.opfPath, href),
+      href: epub.fetcher.resolveHref(epub.opfPath, href, epub.useRelativeHrefs),
     };
 
     // we cast this to make the type wider because it's wrong in r2-shared-js.

--- a/src/convert/resourcesAndReadingOrder.ts
+++ b/src/convert/resourcesAndReadingOrder.ts
@@ -1,7 +1,6 @@
 import { Manifest } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/opf-manifest';
 import Epub from '../Epub';
 import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
-import getLinkEncryption from './encryption';
 
 /**
  * The readingOrder lists the resources of the publication in the reading order
@@ -103,7 +102,7 @@ const manifestToLink =
     };
 
     // add encryption information if present
-    const enc = getLinkEncryption(epub, relativePath);
+    const enc = epub.getLinkEncryption(relativePath);
     if (enc) {
       link.properties = { encrypted: enc };
     }

--- a/src/convert/resourcesAndReadingOrder.ts
+++ b/src/convert/resourcesAndReadingOrder.ts
@@ -91,9 +91,10 @@ const manifestToLink =
     if (!decodedHref) {
       throw new Error(`OPF Link missing HrefDecoded`);
     }
-    const relativePath = epub.fetcher.resolveRelativePath(
+    const relativePath = epub.fetcher.resolveHref(
       epub.opfPath,
-      decodedHref
+      decodedHref,
+      epub.useRelativeHrefs
     );
     const link: LinkWithId = {
       href: relativePath,

--- a/src/convert/resourcesAndReadingOrder.ts
+++ b/src/convert/resourcesAndReadingOrder.ts
@@ -91,13 +91,17 @@ const manifestToLink =
     if (!decodedHref) {
       throw new Error(`OPF Link missing HrefDecoded`);
     }
-    const relativePath = epub.fetcher.resolveHref(
+    const href = epub.fetcher.resolveHref(
       epub.opfPath,
       decodedHref,
       epub.useRelativeHrefs
     );
+    const relativePath = epub.fetcher.resolveRelativePath(
+      epub.opfPath,
+      decodedHref
+    );
     const link: LinkWithId = {
-      href: relativePath,
+      href,
       type: manifest.MediaType,
       id: manifest.ID,
     };


### PR DESCRIPTION
This PR adds an option to make link hrefs absolute instead of relative, thereby supporting webpubs where the contents are located remotely from the manifest itself. This is necessary for AxisNow webpubs.