### PR TITLE
Fix SFR-1337

### DIFF
--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -247,9 +247,10 @@ export default class Epub {
    * an <item> in the <manifest> with id === 'ncx
    */
   static getNcxHref(opf: OPF) {
-    return opf.Manifest.find(
-      (item) => item.ID === 'ncx' && item.MediaType === Epub.NCX_MEDIA_TYPE
-    )?.HrefDecoded;
+    const manifest = opf.Manifest.find(
+      (item) => item.MediaType === Epub.NCX_MEDIA_TYPE
+    );
+    return manifest?.HrefDecoded;
   }
 
   /**


### PR DESCRIPTION
This PR relaxes the search for an NCX file to only rely on the media type, not on the id. Not sure why I used the id in the first place, but this should work and fixes the CPW issue.