### PR TITLE
get correct encryption info

### DIFF
--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -135,7 +135,6 @@ export default class Epub {
         navDoc = Epub.parseNavDoc(navDocStr);
       }
     }
-    console.log(navDocPath);
 
     return new Epub(
       fetcher,


### PR DESCRIPTION
This PR fixes SFR-1350 causing TOCs not to load because we were incorrectly passing an absolute href into `getEncryptionInfo` instead of a relative href for the toc.ncx and navdoc files. 