### PR TITLE
Update reading order generator function

### DIFF
--- a/samples/epub-3-subdir-navdoc/OPS/package.opf
+++ b/samples/epub-3-subdir-navdoc/OPS/package.opf
@@ -10,6 +10,8 @@
     <meta refines="#creator" property="role" scheme="marc:relators">aut</meta>
   </metadata>
   <manifest>
+     <item id="font.stix.regular" href="subdir/1902/fonts/STIXGeneral.otf"
+      media-type="application/vnd.ms-opentype"/>
     <item id="toc" properties="nav" href="subdir/1902/toc.xhtml" media-type="application/xhtml+xml"/>
     <item id="xchapter_001" href="subdir/1902/chapter_001.xhtml" media-type="application/xhtml+xml"/>
     <!-- 

--- a/src/__tests__/LocalExplodedEpub.test.ts
+++ b/src/__tests__/LocalExplodedEpub.test.ts
@@ -45,7 +45,8 @@ describe('Moby EPUB 2 Exploded', () => {
       manifest.readingOrder,
       mobyEpub2Manifest.readingOrder,
       'href',
-      'type'
+      'type',
+      'rel'
     );
   });
 
@@ -57,7 +58,7 @@ describe('Moby EPUB 2 Exploded', () => {
       mobyEpub2Manifest.resources,
       'href',
       'type',
-      'type'
+      'rel'
     );
   });
 
@@ -100,7 +101,8 @@ describe('Moby EPUB 3 Exploded', () => {
       manifest.readingOrder,
       mobyEpub3Manifest.readingOrder,
       'href',
-      'type'
+      'type',
+      'rel'
     );
   });
 
@@ -110,7 +112,8 @@ describe('Moby EPUB 3 Exploded', () => {
       manifest.resources as any,
       mobyEpub3Manifest.resources,
       'href',
-      'type'
+      'type',
+      'rel'
     );
   });
 

--- a/src/__tests__/RemoteExplodedEpub.test.ts
+++ b/src/__tests__/RemoteExplodedEpub.test.ts
@@ -97,7 +97,8 @@ describe('Moby EPUB 3 Exploded', () => {
       manifest.readingOrder,
       mobyEpub3Manifest.readingOrder,
       'href',
-      'type'
+      'type',
+      'rel'
     );
   });
 
@@ -108,7 +109,7 @@ describe('Moby EPUB 3 Exploded', () => {
       mobyEpub3Manifest.resources,
       'href',
       'type',
-      'type'
+      'rel'
     );
   });
 
@@ -153,7 +154,8 @@ describe('Absolute Hrefs', () => {
       manifest.readingOrder,
       mobyAbsoluteHrefs.readingOrder,
       'href',
-      'type'
+      'type',
+      'rel'
     );
   });
 
@@ -164,7 +166,7 @@ describe('Absolute Hrefs', () => {
       mobyAbsoluteHrefs.resources,
       'href',
       'type',
-      'type'
+      'rel'
     );
   });
 
@@ -201,7 +203,7 @@ describe('With NavDoc in a subdirectory', () => {
       epub3Subdir.resources,
       'href',
       'type',
-      'type'
+      'rel'
     );
   });
 

--- a/src/__tests__/stubs/moby-epub2.ts
+++ b/src/__tests__/stubs/moby-epub2.ts
@@ -139,6 +139,8 @@ const mobyEpub2Manifest = {
   resources: [
     {
       type: 'image/png',
+      height: 1800,
+      width: 1200,
       href: 'OEBPS/@export@sunsite@users@gutenbackend@cache@epub@2701@2701-cover.png',
     },
     {

--- a/src/__tests__/stubs/moby-epub2.ts
+++ b/src/__tests__/stubs/moby-epub2.ts
@@ -139,9 +139,6 @@ const mobyEpub2Manifest = {
   resources: [
     {
       type: 'image/png',
-      height: 1800,
-      width: 1200,
-      rel: 'cover',
       href: 'OEBPS/@export@sunsite@users@gutenbackend@cache@epub@2701@2701-cover.png',
     },
     {

--- a/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
+++ b/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
@@ -599,6 +599,7 @@ const mobyEpub3Manifest = {
     {
       type: 'application/xhtml+xml',
       href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc.xhtml',
+      rel: 'contents',
     },
   ],
   resources: [

--- a/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
+++ b/src/__tests__/stubs/moby-epub3-absolute-hrefs.ts
@@ -26,6 +26,10 @@ const mobyEpub3Manifest = {
   readingOrder: [
     {
       type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/cover.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
       href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/titlepage.xhtml',
     },
     {
@@ -592,6 +596,10 @@ const mobyEpub3Manifest = {
       type: 'application/xhtml+xml',
       href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/copyright.xhtml',
     },
+    {
+      type: 'application/xhtml+xml',
+      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc.xhtml',
+    },
   ],
   resources: [
     {
@@ -609,15 +617,6 @@ const mobyEpub3Manifest = {
     {
       type: 'application/vnd.ms-opentype',
       href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/fonts/STIXGeneralBolIta.otf',
-    },
-    {
-      type: 'application/xhtml+xml',
-      rel: 'contents',
-      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/toc.xhtml',
-    },
-    {
-      type: 'application/xhtml+xml',
-      href: 'http://remote.dev/samples/moby-epub3-exploded/OPS/cover.xhtml',
     },
     {
       type: 'image/jpeg',

--- a/src/__tests__/stubs/moby-epub3-subdir-navdoc.ts
+++ b/src/__tests__/stubs/moby-epub3-subdir-navdoc.ts
@@ -17,6 +17,7 @@ const mobyEpub3Manifest = {
     {
       type: 'application/xhtml+xml',
       href: 'OPS/subdir/1902/toc.xhtml',
+      rel: 'contents',
     },
   ],
   resources: [

--- a/src/__tests__/stubs/moby-epub3-subdir-navdoc.ts
+++ b/src/__tests__/stubs/moby-epub3-subdir-navdoc.ts
@@ -14,13 +14,15 @@ const mobyEpub3Manifest = {
       type: 'application/xhtml+xml',
       href: 'OPS/subdir/1902/chapter_001.xhtml',
     },
+    {
+      type: 'application/xhtml+xml',
+      href: 'OPS/subdir/1902/toc.xhtml',
+    },
   ],
   resources: [
     {
-      href: 'OPS/subdir/1902/toc.xhtml',
-      type: 'application/xhtml+xml',
-      id: 'toc',
-      rel: 'contents',
+      type: 'application/vnd.ms-opentype',
+      href: 'OPS/subdir/1902/fonts/STIXGeneral.otf',
     },
   ],
   toc: [

--- a/src/__tests__/stubs/moby-epub3.ts
+++ b/src/__tests__/stubs/moby-epub3.ts
@@ -26,6 +26,10 @@ const mobyEpub3Manifest = {
   readingOrder: [
     {
       type: 'application/xhtml+xml',
+      href: 'OPS/cover.xhtml',
+    },
+    {
+      type: 'application/xhtml+xml',
       href: 'OPS/titlepage.xhtml',
     },
     {
@@ -592,6 +596,10 @@ const mobyEpub3Manifest = {
       type: 'application/xhtml+xml',
       href: 'OPS/copyright.xhtml',
     },
+    {
+      type: 'application/xhtml+xml',
+      href: 'OPS/toc.xhtml',
+    },
   ],
   resources: [
     {
@@ -609,15 +617,6 @@ const mobyEpub3Manifest = {
     {
       type: 'application/vnd.ms-opentype',
       href: 'OPS/fonts/STIXGeneralBolIta.otf',
-    },
-    {
-      type: 'application/xhtml+xml',
-      rel: 'contents',
-      href: 'OPS/toc.xhtml',
-    },
-    {
-      type: 'application/xhtml+xml',
-      href: 'OPS/cover.xhtml',
     },
     {
       type: 'image/jpeg',

--- a/src/__tests__/stubs/moby-epub3.ts
+++ b/src/__tests__/stubs/moby-epub3.ts
@@ -599,6 +599,7 @@ const mobyEpub3Manifest = {
     {
       type: 'application/xhtml+xml',
       href: 'OPS/toc.xhtml',
+      rel: 'contents',
     },
   ],
   resources: [

--- a/src/convert/resourcesAndReadingOrder.ts
+++ b/src/convert/resourcesAndReadingOrder.ts
@@ -1,7 +1,6 @@
 import { Manifest } from 'r2-shared-js/dist/es8-es2017/src/parser/epub/opf-manifest';
 import Epub from '../Epub';
 import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
-import getLinkEncryption from './encryption';
 
 /**
  * The readingOrder lists the resources of the publication in the reading order
@@ -23,10 +22,8 @@ export async function resourcesAndReadingOrder(
     (acc, item) => {
       const link = allResources.find((link) => link.id === item.IDref);
       if (link) {
-        if (!item.Linear || item.Linear === 'yes') {
-          acc.push(link);
-          appearsInReadingOrder[link.id] = true;
-        }
+        acc.push(link);
+        appearsInReadingOrder[link.id] = true;
       }
       return acc;
     },


### PR DESCRIPTION
This PR removes the "Linear" property check when generating the readingOrder from <spine>. This will add all the items listed in the spine spec to the final manifest json.

This fixes the bug when sometimes the TOC contains links that readingOrder does not.