### PR TITLE
OE-273 use an empty toc when none is provided

### DIFF
--- a/src/__tests__/EpubErrors.test.ts
+++ b/src/__tests__/EpubErrors.test.ts
@@ -10,23 +10,23 @@ async function getManifest(container: string) {
 }
 
 describe('EPUB 2', () => {
-  it('extracts toc', async () => {
+  it('extracts empty toc when NavPoints are missing', async () => {
     const container = path.resolve(
       __dirname,
       '../../samples/epub2-missing-navpoints/META-INF/container.xml'
     );
     const manifest = await getManifest(container);
-    expect(manifest.toc).toBe(undefined);
+    expect(manifest.toc).toEqual([]);
   });
 });
 
 describe('EPUB 3', () => {
-  it('extracts undefined TOC when NavPoints are missing', async () => {
+  it('extracts empty TOC when ListItems are missing', async () => {
     const container = path.resolve(
       __dirname,
       '../../samples/epub3-missing-listitems/META-INF/container.xml'
     );
     const manifest = await getManifest(container);
-    expect(manifest.toc).toBe(undefined);
+    expect(manifest.toc).toEqual([]);
   });
 });

--- a/src/convert/navdoc.ts
+++ b/src/convert/navdoc.ts
@@ -19,14 +19,14 @@ const select = xpath.useNamespaces({
  * whereas EPUB 2s put that info in the NCX file. This function
  * extracts TOC information for the manifest from the Nav Document
  */
-export function extractTocFromNavDoc(epub: Epub): ReadiumLink[] | undefined {
+export function extractTocFromNavDoc(epub: Epub): ReadiumLink[] {
   const { navDoc } = epub;
 
   // we only care about the toc nav currently. In the future we can
   // parse the other navs, like PageList
   const tocListItems = selectListItems(navDoc);
 
-  const toc = tocListItems?.map(listItemToLink(epub));
+  const toc = tocListItems?.map(listItemToLink(epub)) ?? [];
   return toc;
 }
 

--- a/src/convert/ncx.ts
+++ b/src/convert/ncx.ts
@@ -8,13 +8,10 @@ import { ReadiumLink } from '../WebpubManifestTypes/ReadiumLink';
  * TOC. The spec is here:
  * http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1
  */
-export function extractTocFromNcx(
-  epub: Epub,
-  ncx: NCX
-): ReadiumLink[] | undefined {
+export function extractTocFromNcx(epub: Epub, ncx: NCX): ReadiumLink[] {
   const points = ncx.Points as NavPoint[] | undefined;
 
-  const toc = points?.map(navPointToLink(epub));
+  const toc = points?.map(navPointToLink(epub)) ?? [];
 
   return toc;
 }


### PR DESCRIPTION
This PR makes us not use `undefined` for `toc` when none is provided or it can't be extracted. Instead we use an empty array `[]`. This is because R2D2BC does not behave properly when `toc` is undefined.