### PR TITLE
Feat/add identifier

### DIFF
--- a/samples/moby-epub2-exploded/OEBPS/content.opf
+++ b/samples/moby-epub2-exploded/OEBPS/content.opf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<package xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="id">
+<package xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="http://www.gutenberg.org/2701">
   <metadata>
     <dc:rights>Public domain in the USA.</dc:rights>
     <dc:identifier opf:scheme="URI" id="id">http://www.gutenberg.org/2701</dc:identifier>

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -250,7 +250,7 @@ export default class Epub {
 
   /**
    * As best I can tell, the TOC.ncx file is always referenced with
-   * an <item> in the <manifest> with id === 'ncx
+   * an <item> in the <manifest> with id === 'ncx'
    */
   static getNcxHref(opf: OPF) {
     const manifest = opf.Manifest.find(

--- a/src/__tests__/LocalExplodedEpub.test.ts
+++ b/src/__tests__/LocalExplodedEpub.test.ts
@@ -35,7 +35,8 @@ describe('Moby EPUB 2 Exploded', () => {
       mobyEpub2Manifest.metadata,
       'author',
       'title',
-      'language'
+      'language',
+      'identifier'
     );
   });
 
@@ -91,7 +92,8 @@ describe('Moby EPUB 3 Exploded', () => {
       manifest.metadata,
       mobyEpub3Manifest.metadata,
       'title',
-      'language'
+      'language',
+      'identifier'
     );
   });
 

--- a/src/__tests__/stubs/moby-epub3.ts
+++ b/src/__tests__/stubs/moby-epub3.ts
@@ -3,7 +3,7 @@ const mobyEpub3Manifest = {
   metadata: {
     '@type': 'http://schema.org/Book',
     title: 'Moby-Dick',
-    identifier: 'code.google.com.epub-samples.moby-dick-basic',
+    identifier: 'pub-id',
     author: {
       name: 'Herman Melville',
       sortAs: 'MELVILLE, HERMAN',

--- a/src/convert/metadata.ts
+++ b/src/convert/metadata.ts
@@ -18,10 +18,12 @@ export function extractMetadata(epub: Epub): WebpubManifest['metadata'] {
   const language = epub.extractMetadataMember('Language');
   const title = extractTitle(epub);
   const contributors = extractContributors(epub);
+  const identifier = extractIdentifier(epub);
 
   return {
     title,
     language: language.length > 1 ? language : language[0],
+    identifier,
     ...contributors,
   };
 }
@@ -90,4 +92,18 @@ function extractContributors(epub: Epub): Contributors {
   }
 
   return contributors;
+}
+
+/**
+ * An OPF Package Document can contain many identifiers in its metadata field.
+ * However, it also must have a single unique-identifier attribute on the `package`
+ * element. This string must be unique to this package document. We will use this.
+ *
+ * For a spec of OPF <identifier> elements, see:
+ *    http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2.10
+ * For a spec of unique-identifier attributes, see:
+ *    http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.1
+ */
+function extractIdentifier(epub: Epub): string {
+  return epub.opf.UniqueIdentifier;
 }


### PR DESCRIPTION
Simply extracts the unique identifier attribute from an OPF file and adds it to the webpub manifest metadata field. 