### PR TITLE
OE-422: Epub Conversion Failure error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/epub-to-webpub",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "repository": "https://github.com/NYPL/ePub-to-webpub",
   "author": "kristojorg",

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -87,23 +87,21 @@ export default class Epub {
     const encryptionDoc = Epub.parseEncryptionDoc(encryptionStr);
 
     // ncx file
-    const relativeNcxPath = Epub.getNcxHref(opf);
-    const relativeEncryptedNcxPath = Epub.resolvePathToOpfPath(
-      fetcher,
+    const ncxPathRelativeToOpf = Epub.getNcxHref(opf);
+    // encrypted path
+    const ncxPathRelativeToRoot = fetcher.resolveRelativePath(
       opfPath,
-      relativeNcxPath
+      ncxPathRelativeToOpf
     );
 
-    const ncxPath = relativeNcxPath
-      ? fetcher.resolvePath(opfPath, relativeNcxPath)
-      : undefined;
+    const ncxPath = fetcher.resolvePath(opfPath, ncxPathRelativeToOpf);
 
     let ncx: NCX | undefined = undefined;
-    if (ncxPath && relativeNcxPath && relativeEncryptedNcxPath) {
+    if (ncxPath && ncxPathRelativeToRoot) {
       // it is encrypted if there is an entry for it in encryption.xml
       const ncxIsEncrypted = !!getEncryptionInfo(
         encryptionDoc,
-        relativeEncryptedNcxPath,
+        ncxPathRelativeToRoot,
         isAxisNow
       );
       if (ncxIsEncrypted) {
@@ -119,21 +117,19 @@ export default class Epub {
     }
 
     // navdoc file
-    const relativeNavDocPath = Epub.getNavDocHref(opf);
-    const relativeEncryptedNavDocPath = Epub.resolvePathToOpfPath(
-      fetcher,
+    const navDocPathRelativeToOpf = Epub.getNavDocHref(opf);
+    // encrypted path
+    const navDocPathRelativeToRoot = fetcher.resolveRelativePath(
       opfPath,
-      relativeNavDocPath
+      navDocPathRelativeToOpf
     );
-    const navDocPath = relativeNavDocPath
-      ? fetcher.resolvePath(opfPath, relativeNavDocPath)
-      : undefined;
+    const navDocPath = fetcher.resolvePath(opfPath, navDocPathRelativeToOpf);
 
     let navDoc: Document | undefined = undefined;
-    if (navDocPath && relativeNavDocPath && relativeEncryptedNavDocPath) {
+    if (navDocPath && navDocPathRelativeToRoot) {
       const isNavDocEncrypted = !!getEncryptionInfo(
         encryptionDoc,
-        relativeEncryptedNavDocPath,
+        navDocPathRelativeToRoot,
         isAxisNow
       );
       if (isNavDocEncrypted) {
@@ -276,20 +272,6 @@ export default class Epub {
    */
   static parseNcx(ncxStr: string | undefined) {
     return ncxStr ? Epub.parseXmlString<NCX>(ncxStr, NCX) : undefined;
-  }
-
-  /**
-   * Convert the relative href relative to the opfPath, that's the OEBPS or ops folder
-   * This is to keep things consistant and make opfPath the main root folder for encrypted contents
-   */
-  static resolvePathToOpfPath(
-    fetcher: Fetcher,
-    opfPath: string,
-    href: string | undefined
-  ) {
-    if (!href) return undefined;
-
-    return fetcher.resolveRelativePath(opfPath, href);
   }
 
   static getNavDocHref(opf: OPF): string | undefined {

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -86,7 +86,12 @@ export default class Epub {
     const encryptionDoc = Epub.parseEncryptionDoc(encryptionStr);
 
     // ncx file
-    const relativeNcxPath = Epub.getNcxHref(opf);
+    const ncxHref = Epub.getNcxHref(opf);
+    const relativeNcxPath = Epub.resolvePathToOpfPath(
+      fetcher,
+      opfPath,
+      ncxHref
+    );
     const ncxPath = relativeNcxPath
       ? fetcher.resolvePath(opfPath, relativeNcxPath)
       : undefined;
@@ -112,7 +117,12 @@ export default class Epub {
     }
 
     // navdoc file
-    const relativeNavDocPath = Epub.getNavDocHref(opf);
+    const navDocHref = Epub.getNavDocHref(opf);
+    const relativeNavDocPath = Epub.resolvePathToOpfPath(
+      fetcher,
+      opfPath,
+      navDocHref
+    );
     const navDocPath = relativeNavDocPath
       ? fetcher.resolvePath(opfPath, relativeNavDocPath)
       : undefined;
@@ -264,6 +274,20 @@ export default class Epub {
    */
   static parseNcx(ncxStr: string | undefined) {
     return ncxStr ? Epub.parseXmlString<NCX>(ncxStr, NCX) : undefined;
+  }
+
+  /**
+   * Convert the relative href relative to the opfPath, that's the OEBPS or ops folder
+   * This is to keep things consistant and make opfPath the main root folder for contents
+   */
+  static resolvePathToOpfPath(
+    fetcher: Fetcher,
+    opfPath: string,
+    href: string | undefined
+  ) {
+    if (!href) return undefined;
+
+    return fetcher.resolveRelativePath(opfPath, href);
   }
 
   static getNavDocHref(opf: OPF): string | undefined {

--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -88,7 +88,6 @@ export default class Epub {
 
     // ncx file
     const ncxPathRelativeToOpf = Epub.getNcxHref(opf);
-    // encrypted path
     const ncxPathRelativeToRoot = fetcher.resolveRelativePath(
       opfPath,
       ncxPathRelativeToOpf
@@ -118,7 +117,6 @@ export default class Epub {
 
     // navdoc file
     const navDocPathRelativeToOpf = Epub.getNavDocHref(opf);
-    // encrypted path
     const navDocPathRelativeToRoot = fetcher.resolveRelativePath(
       opfPath,
       navDocPathRelativeToOpf

--- a/src/Fetcher.ts
+++ b/src/Fetcher.ts
@@ -18,8 +18,16 @@ export default abstract class Fetcher {
   }
 
   abstract resolvePath(from: string, to: string): string;
+  abstract resolvePath(
+    from: string,
+    to: string | undefined
+  ): string | undefined;
   // returns a path relative to the EPUB root
   abstract resolveRelativePath(from: string, to: string): string;
+  abstract resolveRelativePath(
+    from: string,
+    to: string | undefined
+  ): string | undefined;
   // resolves either a relative or absolute href depending on the flag
   abstract resolveHref(from: string, to: string, relative: boolean): string;
 

--- a/src/LocalFetcher.ts
+++ b/src/LocalFetcher.ts
@@ -30,8 +30,10 @@ export default class LocalFetcher extends Fetcher {
   }
 
   resolveRelativePath(from: string, to: string): string;
-  resolveRelativePath(from: string, to: string | undefined): string | undefined;
-  resolveRelativePath(from: string, to: unknown): unknown {
+  resolveRelativePath(
+    from: string,
+    to: string | undefined
+  ): string | undefined {
     if (typeof to !== 'string') return undefined;
     const fullPath = this.resolvePath(from, to);
     return path.relative(this.folderPath, fullPath);

--- a/src/LocalFetcher.ts
+++ b/src/LocalFetcher.ts
@@ -22,10 +22,17 @@ export default class LocalFetcher extends Fetcher {
     return path.resolve(this.containerXmlPath, '../../', relativeOpfPath);
   }
 
-  resolvePath(from: string, to: string): string {
+  resolvePath(from: string, to: string): string;
+  resolvePath(from: string, to: string | undefined): string | undefined;
+  resolvePath(from: string, to: unknown): unknown {
+    if (typeof to !== 'string') return undefined;
     return path.resolve(from, '../', to);
   }
-  resolveRelativePath(from: string, to: string): string {
+
+  resolveRelativePath(from: string, to: string): string;
+  resolveRelativePath(from: string, to: string | undefined): string | undefined;
+  resolveRelativePath(from: string, to: unknown): unknown {
+    if (typeof to !== 'string') return undefined;
     const fullPath = this.resolvePath(from, to);
     return path.relative(this.folderPath, fullPath);
   }

--- a/src/RemoteFetcher.ts
+++ b/src/RemoteFetcher.ts
@@ -50,15 +50,16 @@ export default class RemoteFetcher extends Fetcher {
   }
 
   resolvePath(from: string, to: string): string;
-  resolvePath(from: string, to: string | undefined): string | undefined;
-  resolvePath(from: string, to: unknown): unknown {
+  resolvePath(from: string, to: string | undefined): string | undefined {
     if (typeof to !== 'string') return undefined;
     return new URL(to, from).toString();
   }
 
   resolveRelativePath(from: string, to: string): string;
-  resolveRelativePath(from: string, to: string | undefined): string | undefined;
-  resolveRelativePath(from: string, to: unknown): unknown {
+  resolveRelativePath(
+    from: string,
+    to: string | undefined
+  ): string | undefined {
     if (typeof to !== 'string') return undefined;
     return this.resolvePath(from, to).replace(this.folderPath, '');
   }

--- a/src/RemoteFetcher.ts
+++ b/src/RemoteFetcher.ts
@@ -49,12 +49,20 @@ export default class RemoteFetcher extends Fetcher {
     return this.resolvePath(this.folderPath, relativeOpfPath);
   }
 
-  resolvePath(from: string, to: string): string {
+  resolvePath(from: string, to: string): string;
+  resolvePath(from: string, to: string | undefined): string | undefined;
+  resolvePath(from: string, to: unknown): unknown {
+    if (typeof to !== 'string') return undefined;
     return new URL(to, from).toString();
   }
-  resolveRelativePath(from: string, to: string): string {
+
+  resolveRelativePath(from: string, to: string): string;
+  resolveRelativePath(from: string, to: string | undefined): string | undefined;
+  resolveRelativePath(from: string, to: unknown): unknown {
+    if (typeof to !== 'string') return undefined;
     return this.resolvePath(from, to).replace(this.folderPath, '');
   }
+
   resolveHref(from: string, to: string, relative: boolean) {
     return relative
       ? this.resolveRelativePath(from, to)

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -11,12 +11,9 @@ export function getEncryptionInfo(
   relativePath: string,
   isAxisNow: boolean | undefined
 ) {
-  const encryptionData = encryptionDoc?.EncryptedData.find((data) => {
-    // Href(relativePath) from the opf.Manifest instance does not give you the full path (Without the subpath OEBPS or OPS),
-    // whereas CipherReference.URI has it (e.g. OPS/toc.ncx), so we we have to just check the final patname.
-    // http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.3
-    return data.CipherData.CipherReference.URI.endsWith(relativePath);
-  });
+  const encryptionData = encryptionDoc?.EncryptedData.find(
+    (data) => data.CipherData.CipherReference.URI === relativePath
+  );
   const algorithm = encryptionData?.EncryptionMethod.Algorithm;
   let encryption: EPUBExtensionLinkProperties['encrypted'] = undefined;
   const scheme = encryptionData?.KeyInfo.RetrievalMethod.Type;

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -4,15 +4,16 @@ import { EPUBExtensionLinkProperties } from '../WebpubManifestTypes/EpubExtensio
 
 /**
  * Adds encryption information to the resource link if there is any detected for this
+ * parameter 'path' needs to be relative to the root of the publication
  * link in the epub.encryptionDoc
  */
 export function getEncryptionInfo(
   encryptionDoc: Encryption | undefined,
-  relativePath: string,
+  path: string,
   isAxisNow: boolean | undefined
 ) {
   const encryptionData = encryptionDoc?.EncryptedData.find(
-    (data) => data.CipherData.CipherReference.URI === relativePath
+    (data) => data.CipherData.CipherReference.URI === path
   );
   const algorithm = encryptionData?.EncryptionMethod.Algorithm;
   let encryption: EPUBExtensionLinkProperties['encrypted'] = undefined;

--- a/src/convert/encryption.ts
+++ b/src/convert/encryption.ts
@@ -11,9 +11,12 @@ export function getEncryptionInfo(
   relativePath: string,
   isAxisNow: boolean | undefined
 ) {
-  const encryptionData = encryptionDoc?.EncryptedData.find(
-    (data) => data.CipherData.CipherReference.URI === relativePath
-  );
+  const encryptionData = encryptionDoc?.EncryptedData.find((data) => {
+    // Href(relativePath) from the opf.Manifest instance does not give you the full path (Without the subpath OEBPS or OPS),
+    // whereas CipherReference.URI has it (e.g. OPS/toc.ncx), so we we have to just check the final patname.
+    // http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.3
+    return data.CipherData.CipherReference.URI.endsWith(relativePath);
+  });
   const algorithm = encryptionData?.EncryptionMethod.Algorithm;
   let encryption: EPUBExtensionLinkProperties['encrypted'] = undefined;
   const scheme = encryptionData?.KeyInfo.RetrievalMethod.Type;


### PR DESCRIPTION
Fix the bug where when the encryption file contains the `toc.ncx` path and the `toc.ncx` file needs to be decrypted, the decryption function would fail because it could not identify the URL to the toc location.

The toc.tc URL denoted on the Manifest object is relative to the folder root whereas the URL from the encryption file is relative to the publication root (i.e. OEBPS/, ops/). When resolving the relative path to the toc file, we need to make sure it's relative to the root of the publication.
